### PR TITLE
Get resource type from included serializers

### DIFF
--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -167,10 +167,6 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
         if resource_type is None:
             resource_type = get_resource_type_from_instance(value)
 
-        root = getattr(self.parent, 'parent', None)
-        if root is None:
-            root = self.parent
-
         return OrderedDict([('type', resource_type), ('id', str(pk))])
 
     def get_resource_type_from_included_serializer(self):

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -179,7 +179,7 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
 
         if root is not None:
             includes = get_included_serializers(root)
-            if field_name in includes:
+            if field_name in includes.keys():
                 return get_resource_type_from_serializer(includes[field_name])
 
         return None


### PR DESCRIPTION
Prefer getting resource type from serializer if available. Added support for both "many" and "single" relationships (previous code only worked for many).