### PR TITLE
Python 3.8: reapply patches to version 3.1.0

### DIFF
--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -5,6 +5,7 @@ from rest_framework.fields import MISSING_ERROR_MESSAGE, SerializerMethodField
 from rest_framework.relations import *
 from django.utils.translation import ugettext_lazy as _
 from django.db.models.query import QuerySet
+from django.db.models import Model
 
 from rest_framework_json_api.exceptions import Conflict
 from rest_framework_json_api.utils import Hyperlink, \
@@ -120,8 +121,9 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
             related_id = None
 
         if related_id:
+            if isinstance(related_id, Model):
+                related_id = related_id.pk
             related_kwargs = {self.related_link_url_kwarg: related_id}
-
             related_link = self.get_url('related', self.related_link_view_name, related_kwargs, request)
         else:
             related_link = None

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -106,9 +106,12 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
         self_link = self.get_url('self', self.self_link_view_name, self_kwargs, request)
 
         related_id = getattr(obj, self.related_link_lookup_field) if obj else view.kwargs[self.related_link_lookup_field]
-        related_kwargs = {self.related_link_url_kwarg: related_id}
+        if related_id:
+            related_kwargs = {self.related_link_url_kwarg: related_id}
 
-        related_link = self.get_url('related', self.related_link_view_name, related_kwargs, request)
+            related_link = self.get_url('related', self.related_link_view_name, related_kwargs, request)
+        else:
+            related_link = None
 
         if self_link:
             return_data.update({'self': self_link})

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -229,3 +229,14 @@ class SerializerMethodResourceRelatedField(ResourceRelatedField):
             base = super(SerializerMethodResourceRelatedField, self)
             return [base.to_representation(x) for x in value]
         return super(SerializerMethodResourceRelatedField, self).to_representation(value)
+
+    def get_links(self, obj=None, lookup_field='pk'):
+        if hasattr(self, 'child_relation') and getattr(self, 'child_relation'):
+            return super(SerializerMethodResourceRelatedField, self).get_links(obj, lookup_field)
+
+        if self.source and hasattr(self.parent, self.source):
+            serializer_method = getattr(self.parent, self.source)
+            if hasattr(serializer_method, '__call__'):
+                obj = serializer_method(obj)
+
+        return super(SerializerMethodResourceRelatedField, self).get_links(obj, lookup_field)

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -167,10 +167,6 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
         if resource_type is None:
             resource_type = get_resource_type_from_instance(value)
 
-        root = getattr(self.parent, 'parent', None)
-        if root is None:
-            root = self.parent
-
         return OrderedDict([('type', resource_type), ('id', str(pk))])
 
     def get_resource_type_from_included_serializer(self):

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -35,7 +35,7 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
         if related_link_view_name is not None:
             self.related_link_view_name = related_link_view_name
 
-        self.related_link_lookup_field = kwargs.pop('related_link_lookup_field', self.related_link_lookup_field)
+        self.related_link_lookup_field = kwargs.pop('related_link_lookup_field', None)
         self.related_link_url_kwarg = kwargs.pop('related_link_url_kwarg', self.related_link_lookup_field)
 
         # check for a model class that was passed in for the relation type
@@ -111,7 +111,7 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
         self_link = self.get_url('self', self.self_link_view_name, self_kwargs, request)
 
         if obj:
-            related_id = getattr(obj, self.related_link_lookup_field)
+            related_id = getattr(obj, self.related_link_lookup_field or 'pk')
         elif self.related_link_lookup_field in view.kwargs:
             related_id = view.kwargs[self.related_link_lookup_field]
         else:

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -105,7 +105,9 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
         self_kwargs.update({'related_field': self.field_name if self.field_name else self.parent.field_name})
         self_link = self.get_url('self', self.self_link_view_name, self_kwargs, request)
 
-        related_kwargs = {self.related_link_url_kwarg: kwargs[self.related_link_lookup_field]}
+        related_id = getattr(obj, self.related_link_lookup_field) if obj else view.kwargs[self.related_link_lookup_field]
+        related_kwargs = {self.related_link_url_kwarg: related_id}
+
         related_link = self.get_url('related', self.related_link_view_name, related_kwargs, request)
 
         if self_link:

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -150,7 +150,11 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
         # check to see if this resource has a different resource_name when
         # included and use that name
         resource_type = None
-        root = getattr(self.parent, 'parent', self.parent)
+
+        root = getattr(self.parent, 'parent', None)
+        if root is None:
+            root = self.parent
+
         field_name = self.field_name if self.field_name else self.parent.field_name
         if getattr(root, 'included_serializers', None) is not None:
             includes = get_included_serializers(root)

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -179,7 +179,7 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
 
         if root is not None:
             includes = get_included_serializers(root)
-            if field_name in includes:
+            if field_name in includes.keys():
                 return get_resource_type_from_serializer(includes[field_name])
 
         return None

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -110,7 +110,13 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
         self_kwargs.update({'related_field': self.field_name if self.field_name else self.parent.field_name})
         self_link = self.get_url('self', self.self_link_view_name, self_kwargs, request)
 
-        related_id = getattr(obj, self.related_link_lookup_field) if obj else view.kwargs[self.related_link_lookup_field]
+        if obj:
+            related_id = getattr(obj, self.related_link_lookup_field)
+        elif self.related_link_lookup_field in view.kwargs:
+            related_id = view.kwargs[self.related_link_lookup_field]
+        else:
+            related_id = None
+
         if related_id:
             related_kwargs = {self.related_link_url_kwarg: related_id}
 

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -99,7 +99,12 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
         view = self.context.get('view', None)
         return_data = OrderedDict()
 
-        kwargs = {lookup_field: getattr(obj, lookup_field) if obj else view.kwargs[lookup_field]}
+        if obj:
+            kwargs = {lookup_field: getattr(obj, lookup_field)}
+        elif lookup_field in view.kwargs:
+            kwargs = {lookup_field: view.kwargs[lookup_field]}
+        else:
+            kwargs = {}
 
         self_kwargs = kwargs.copy()
         self_kwargs.update({'related_field': self.field_name if self.field_name else self.parent.field_name})

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -18,6 +18,7 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
     self_link_view_name = None
     related_link_view_name = None
     related_link_lookup_field = 'pk'
+    links_only = False
 
     default_error_messages = {
         'required': _('This field is required.'),
@@ -37,6 +38,7 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
 
         self.related_link_lookup_field = kwargs.pop('related_link_lookup_field', None)
         self.related_link_url_kwarg = kwargs.pop('related_link_url_kwarg', self.related_link_lookup_field)
+        self.links_only = kwargs.pop('links_only', self.links_only)
 
         # check for a model class that was passed in for the relation type
         model = kwargs.pop('model', None)
@@ -153,6 +155,9 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
         return super(ResourceRelatedField, self).to_internal_value(data['id'])
 
     def to_representation(self, value):
+        if self.links_only:
+            return None
+
         if getattr(self, 'pk_field', None) is not None:
             pk = self.pk_field.to_representation(value.pk)
         else:

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -131,7 +131,7 @@ class JSONRenderer(renderers.JSONRenderer):
                 # special case for ResourceRelatedField
                 relation_data = {}
                 field_data = resource.get(field_name)
-                if field_data:
+                if field_data or type(field_data) == list:
                     relation_data['data'] = field_data
 
                 field_links = field.get_links(resource_instance)

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -91,7 +91,11 @@ class JSONRenderer(renderers.JSONRenderer):
                 continue
 
             source = field.source
-            relation_type = utils.get_related_resource_type(field)
+            # Pretty big hack, we don't actually care about the relation type in the case of ManyRelatedField
+            try:
+                relation_type = utils.get_related_resource_type(field)
+            except:
+                relation_type = None
 
             if isinstance(field, relations.HyperlinkedIdentityField):
                 resolved, relation_instance = utils.get_relation_instance(resource_instance, source, field.parent)

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -83,6 +83,9 @@ class JSONRenderer(renderers.JSONRenderer):
             if field_name == api_settings.URL_FIELD_NAME:
                 continue
 
+            if field.write_only:
+                continue
+
             # Skip fields without relations
             if not isinstance(field, (relations.RelatedField, relations.ManyRelatedField, BaseSerializer)):
                 continue

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -443,6 +443,14 @@ class JSONRenderer(renderers.JSONRenderer):
         if resource_name == 'errors':
             return self.render_errors(data, accepted_media_type, renderer_context)
 
+        # if response.status_code is 204 then the data to be rendered must
+        # be None
+        response = renderer_context.get('response', None)
+        if response is not None and response.status_code == 204:
+            return super(JSONRenderer, self).render(
+                None, accepted_media_type, renderer_context
+            )
+
         from rest_framework_json_api.views import RelationshipView
         if isinstance(view, RelationshipView):
             return self.render_relationship_view(data, accepted_media_type, renderer_context)

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -122,9 +122,10 @@ class JSONRenderer(renderers.JSONRenderer):
                     continue
 
                 # special case for ResourceRelatedField
-                relation_data = {
-                    'data': resource.get(field_name)
-                }
+                relation_data = {}
+                field_data = resource.get(field_name)
+                if field_data:
+                    relation_data['data'] = field_data
 
                 field_links = field.get_links(resource_instance)
                 relation_data.update(


### PR DESCRIPTION
Upgrading the version

This version supports python 3.8 without any changes to field behavior.
